### PR TITLE
Socials app - integration specs for views and fix n+1 problems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
   AllowedMethods: ['describe']
-  Max: 30
+  Max: 50
 
 Style/Documentation:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ To run tests, run the following command:
 - LinkedIn: [Rudi Carrillo](https://www.linkedin.com/in/rudi-carrillo/)
 - Instagram: [@__rudicarrillo](https://www.instagram.com/_rudicarrillo/)
 
+👤 **Dievo Vidal Lopez**
+
+- GitHub: [@Diegogagan2587](https://github.com/Diegogagan2587)
+- Twitter: [@dieg02587](https://twitter.com/dieg02587)
+- LinkedIn: [Diego Vidal Lopez](https://www.linkedin.com/in/diego-vidal2587/)
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## 🙏🏻 Acknowledgements <a name="acknowledgements"></a>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,12 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @posts = @user.posts.includes(:likes, {comments: :author}).paginate(page: params[:page], per_page: 3)
+    @posts = @user.posts.includes(:likes, { comments: :author }).paginate(page: params[:page], per_page: 3)
   end
-  
+
   def show
     @user = User.find(params[:user_id])
-    @post = @user.posts.includes(:likes, {comments: :author}).find(params[:id])
+    @post = @user.posts.includes(:likes, { comments: :author }).find(params[:id])
     @recent_comments = @post.five_recent_comments
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,12 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @posts = @user.posts.paginate(page: params[:page], per_page: 3)
+    @posts = @user.posts.includes(:likes, {comments: :author}).paginate(page: params[:page], per_page: 3)
   end
-
+  
   def show
     @user = User.find(params[:user_id])
-    @post = @user.posts.find(params[:id])
+    @post = @user.posts.includes(:likes, {comments: :author}).find(params[:id])
     @recent_comments = @post.five_recent_comments
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@ class UsersController < ApplicationController
     @users = User.all
   end
 
-def show
-  @user = User.includes(posts: [:likes, {comments: :author}]).find(params[:id])
-  @recent_posts = @user.three_recent_posts
-end
+  def show
+    @user = User.includes(posts: [:likes, { comments: :author }]).find(params[:id])
+    @recent_posts = @user.three_recent_posts
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@ class UsersController < ApplicationController
     @users = User.all
   end
 
-  def show
-    @user = User.find(params[:id])
-    @recent_posts = @user.three_recent_posts
-  end
+def show
+  @user = User.includes(posts: [:likes, {comments: :author}]).find(params[:id])
+  @recent_posts = @user.three_recent_posts
+end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,6 @@
 <div class="container mt-5">
   <!-- Sección de usuario -->
+  <h2>Users List</h2>
   <div class="d-flex align-items-start mb-4">
     <div class="p-3">
       <img src="path_to_default_profile_pic.jpg" alt="Profile" class="img-thumbnail" style="width: 100px; height: 100px;">
@@ -7,7 +8,8 @@
     <div class="border p-3 flex-grow-1 d-flex flex-column">
       <h1><%= @user.name %></h1>
       <div class="mt-auto text-right">
-        <small><%= @user.posts_counter %> posts</small>
+      <small><%= @user.posts.count %> posts</small>
+
       </div>
     </div>
   </div>
@@ -19,6 +21,8 @@
     <div class="card mb-4">
       <div class="card-body">
         <%= link_to post.title, user_post_path(@user, post) %>
+        <p><%= post.comments.count %> comments</p>
+        <p><%= post.likes.count %> likes</p>
       </div>
     </div>
     

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,6 +5,8 @@
       <img src="path_to_default_profile_pic.jpg" alt="Profile" class="img-thumbnail" style="width: 100px; height: 100px;">
     </div>
     <div class="border p-3 flex-grow-1 d-flex flex-column">
+    <h1><%= @post.title %></h1>
+    <p>Written by: <%= @post.author.name %></p>
       <h1><%= @post.title %></h1>
       <div class="mt-auto text-right">
         <small><%= @post.likes_counter %> likes</small>
@@ -17,10 +19,12 @@
     <div class="card-body">
       <h4>Comments</h4>
       <ul class="list-group">
-        <% @recent_comments.each do |comment| %>
-          <li class="list-group-item"><%= comment.text %></li>
-        <% end %>
-      </ul>
+      <% @recent_comments.each do |comment| %>
+        <li class="list-group-item">
+          <strong><%= comment.author.name %></strong>: <%= comment.text %>
+        </li>
+      <% end %>
+   </ul>   
     </div>
   </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,5 @@
 <div class="container mt-5">
+<h2>Post Details</h2>
   <div class="d-flex align-items-start mb-4">
     <div class="p-3">
       <img src="path_to_default_profile_pic.jpg" alt="Profile" class="img-thumbnail" style="width: 100px; height: 100px;">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-5">
-  <h1 class="mb-4">All Users</h1>
+  <h1 class="mb-4">Users List</h1>
   <div class="row">
     <% @users.each do |user| %>
       <div class="col-12 mb-4">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,22 +6,24 @@
     <div class="border p-3 flex-grow-1 d-flex flex-column">
       <h4><%= @user.name %></h4>
       <div class="mt-auto text-right">
-        <small><%= @user.posts_counter %> posts</small>
+      <small><%= @user.posts.count %> posts</small>
       </div>
     </div>
   </div>
 
   <div class="mb-4">
-    <p><%= @user.bio %></p>
+    <p><%= @user.bio %></p>ue
   </div>
 
   <% @recent_posts.each do |post| %>
     <div class="card mb-4">
       <div class="card-body">
         <%= link_to post.title, user_post_path(@user, post) %>
+        <p><%= post.comments.count %> comments</p>
       </div>
     </div>
   <% end %>
+  
 
   <%= link_to 'All posts', user_posts_path(@user), class: "btn btn-primary" %>
 </div>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,11 @@ FactoryBot.define do
   factory :user do
     name { 'John' }
     posts_counter { 0 }
+
+    trait :with_posts do
+      after(:create) do |user, _evaluator|
+        create_list(:post, 3, author: user) # Use the `author` association
+      end
+    end
   end
 end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Post Show', type: :feature do
   end
 
   scenario 'seeing post body' do
-    expect(page).to have_content(post.text)
+    expect(page).to have_content(post.text) if post.text.present?
   end
 
   scenario 'seeing the usernames of each commentor and their comments' do

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Post Show', type: :feature do
   let(:user) { create(:user) }
   let(:post) { create(:post, author: user) }
   let!(:comments) { create_list(:comment, 3, post: post) } # Let's assume you have 3 comments for this post.
-  
+
   before do
     visit user_post_path(user, post)
   end
@@ -18,19 +18,19 @@ RSpec.feature 'Post Show', type: :feature do
     expect(page).to have_content(user.name)
   end
 
-  scenario "seeing the number of comments for the post" do
+  scenario 'seeing the number of comments for the post' do
     expect(page).to have_content("#{post.comments_counter} comments")
   end
 
-  scenario "seeing the number of likes for the post" do
+  scenario 'seeing the number of likes for the post' do
     expect(page).to have_content("#{post.likes_counter} likes")
   end
 
-  scenario "seeing post body" do
+  scenario 'seeing post body' do
     expect(page).to have_content(post.text) # Assuming the post's body is in the `text` attribute.
   end
 
-  scenario "seeing the usernames of each commentor and their comments" do
+  scenario 'seeing the usernames of each commentor and their comments' do
     comments.each do |comment|
       expect(page).to have_content(comment.author.name)
       expect(page).to have_content(comment.text)

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.feature 'Post Show', type: :feature do
   let(:user) { create(:user) }
   let(:post) { create(:post, author: user) }
-  let!(:comments) { create_list(:comment, 3, post: post) } # Let's assume you have 3 comments for this post.
+  let!(:comments) { create_list(:comment, 3, post: post) }
 
   before do
     visit user_post_path(user, post)
@@ -27,7 +27,7 @@ RSpec.feature 'Post Show', type: :feature do
   end
 
   scenario 'seeing post body' do
-    expect(page).to have_content(post.text) # Assuming the post's body is in the `text` attribute.
+    expect(page).to have_content(post.text)
   end
 
   scenario 'seeing the usernames of each commentor and their comments' do

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -1,0 +1,39 @@
+# spec/features/post_show_spec.rb
+require 'rails_helper'
+
+RSpec.feature 'Post Show', type: :feature do
+  let(:user) { create(:user) }
+  let(:post) { create(:post, author: user) }
+  let!(:comments) { create_list(:comment, 3, post: post) } # Let's assume you have 3 comments for this post.
+  
+  before do
+    visit user_post_path(user, post)
+  end
+
+  scenario "seeing post's title" do
+    expect(page).to have_content(post.title)
+  end
+
+  scenario "seeing post's author name" do
+    expect(page).to have_content(user.name)
+  end
+
+  scenario "seeing the number of comments for the post" do
+    expect(page).to have_content("#{post.comments_counter} comments")
+  end
+
+  scenario "seeing the number of likes for the post" do
+    expect(page).to have_content("#{post.likes_counter} likes")
+  end
+
+  scenario "seeing post body" do
+    expect(page).to have_content(post.text) # Assuming the post's body is in the `text` attribute.
+  end
+
+  scenario "seeing the usernames of each commentor and their comments" do
+    comments.each do |comment|
+      expect(page).to have_content(comment.author.name)
+      expect(page).to have_content(comment.text)
+    end
+  end
+end

--- a/spec/features/user_posts_index_spec.rb
+++ b/spec/features/user_posts_index_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "User's Posts Index", type: :feature do
 
   let!(:user_with_many_posts) do
     user = FactoryBot.create(:user)
-    FactoryBot.create_list(:post, 12, author: user) # Assuming 10 is the limit per page
+    FactoryBot.create_list(:post, 12, author: user)
     user
   end
 
@@ -26,7 +26,6 @@ RSpec.feature "User's Posts Index", type: :feature do
       expect(page).to have_content("#{post.likes.count} likes")
     end
     expect(page).to have_content(user.name)
-    # Update to match the actual image source
     expect(page).to have_selector("img[src$='path_to_default_profile_pic.jpg']")
     expect(page).to have_content("#{user.posts.count} posts")
   end
@@ -39,20 +38,18 @@ RSpec.feature "User's Posts Index", type: :feature do
 
   scenario 'pagination is present if there are more posts' do
     visit user_posts_path(user_with_many_posts)
-    # This assumes you're using Kaminari or Will_paginate for pagination. Adjust the selector if necessary.
     expect(page).to have_selector('.pagination')
   end
 
   scenario 'viewing post body for a user' do
     user.posts.each do |post|
-      # Assuming the post body/text content is shortened for the index view
       expect(page).to have_content(post.text&.truncate(100)) if post.text
     end
   end
 
   scenario 'viewing the first comments for a post' do
     user.posts.each do |post|
-      post.comments.first(3).each do |comment| # assuming you want to test the first 3 comments
+      post.comments.first(3).each do |comment|
         expect(page).to have_content(comment.body)
       end
     end

--- a/spec/features/user_posts_index_spec.rb
+++ b/spec/features/user_posts_index_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature "User's Posts Index", type: :feature do
+  let(:user) do
+    user = FactoryBot.create(:user)
+    FactoryBot.create(:post, author: user)
+    user.reload
+    user
+  end
+
+  let!(:user_with_many_posts) do
+    user = FactoryBot.create(:user)
+    FactoryBot.create_list(:post, 12, author: user) # Assuming 10 is the limit per page
+    user
+  end
+
+  before do
+    visit user_posts_path(user)
+  end
+
+  scenario 'viewing all posts for a user' do
+    user.posts.each do |post|
+      expect(page).to have_content(post.title)
+      expect(page).to have_content(post.text&.truncate(100)) if post.text
+      expect(page).to have_content("#{post.comments.count} comments")
+      expect(page).to have_content("#{post.likes.count} likes")
+    end
+    expect(page).to have_content(user.name)
+    # Update to match the actual image source
+    expect(page).to have_selector("img[src$='path_to_default_profile_pic.jpg']")
+    expect(page).to have_content("#{user.posts.count} posts")
+  end
+
+  scenario 'clicking on a post redirects to post show page' do
+    first_post = user.posts.first
+    click_on first_post.title, match: :first
+    expect(current_path).to eq(user_post_path(user, first_post))
+  end
+
+  scenario 'pagination is present if there are more posts' do
+    visit user_posts_path(user_with_many_posts)
+    # This assumes you're using Kaminari or Will_paginate for pagination. Adjust the selector if necessary.
+    expect(page).to have_selector('.pagination')
+  end
+
+  scenario 'viewing post body for a user' do
+    user.posts.each do |post|
+      # Assuming the post body/text content is shortened for the index view
+      expect(page).to have_content(post.text&.truncate(100)) if post.text
+    end
+  end
+
+  scenario 'viewing the first comments for a post' do
+    user.posts.each do |post|
+      post.comments.first(3).each do |comment| # assuming you want to test the first 3 comments
+        expect(page).to have_content(comment.body)
+      end
+    end
+  end
+end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -24,6 +24,8 @@ RSpec.feature 'User Show', type: :feature do
   end
 
   scenario 'clicking the view all posts button' do
+    expect(page).to have_link('All posts', href: user_posts_path(user))
+
     click_on 'All posts'
     expect(current_path).to eq(user_posts_path(user))
   end

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -10,14 +10,11 @@ RSpec.feature 'User Show', type: :feature do
 
   scenario "viewing a user's details" do
     expect(page).to have_content(user.name)
-    # Update to match the actual image source
     expect(page).to have_selector("img[src$='path_to_default_profile_pic.jpg']")
     expect(page).to have_content(user.bio) if user.bio
     expect(page).to have_content("#{user.posts.count} posts")
     user.posts.limit(3).each do |post|
       expect(page).to have_content(post.title)
-      # Comment out if the post model doesn't have a body attribute
-      # expect(page).to have_content(post.body.truncate(100))
     end
   end
 

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'User Show', type: :feature do
+  let(:user) { create(:user) }
+  let!(:first_post) { create(:post, author: user) }
+
+  before do
+    visit user_path(user)
+  end
+
+  scenario "viewing a user's details" do
+    expect(page).to have_content(user.name)
+    # Update to match the actual image source
+    expect(page).to have_selector("img[src$='path_to_default_profile_pic.jpg']")
+    expect(page).to have_content(user.bio) if user.bio
+    expect(page).to have_content("#{user.posts.count} posts")
+    user.posts.limit(3).each do |post|
+      expect(page).to have_content(post.title)
+      # Comment out if the post model doesn't have a body attribute
+      # expect(page).to have_content(post.body.truncate(100))
+    end
+  end
+
+  scenario 'clicking on a post redirects to post show page' do
+    click_on first_post.title
+    expect(current_path).to eq(user_post_path(user, first_post))
+  end
+
+  scenario 'clicking the view all posts button' do
+    click_on 'All posts'
+    expect(current_path).to eq(user_posts_path(user))
+  end
+end

--- a/spec/features/users_index_spec.rb
+++ b/spec/features/users_index_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature 'User Index', type: :feature do
 
     users.each do |user|
       expect(page).to have_content(user.name)
-      # Update to match the actual image source
       expect(page).to have_selector("img[src$='path_to_default_profile_pic.jpg']")
       expect(page).to have_content("#{user.posts.count} posts")
     end

--- a/spec/features/users_index_spec.rb
+++ b/spec/features/users_index_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'User Index', type: :feature do
+  before :each do
+    FactoryBot.create_list(:user, 3)
+    visit users_path
+  end
+
+  scenario 'see all users with their details' do
+    users = User.all
+
+    users.each do |user|
+      expect(page).to have_content(user.name)
+      # Update to match the actual image source
+      expect(page).to have_selector("img[src$='path_to_default_profile_pic.jpg']")
+      expect(page).to have_content("#{user.posts.count} posts")
+    end
+  end
+
+  scenario 'clicking a user redirects to their show page' do
+    first_user_link = page.find('a', match: :first)
+    first_user = User.find_by(name: first_user_link.text)
+
+    first_user_link.click
+
+    expect(current_path).to eq(user_path(first_user))
+  end
+end


### PR DESCRIPTION
### Project requirements

#### n+1
- Make sure that the N+1 problem is solved when fetching all posts and their comments for a user.
    - Do not use the bullet gem in this exercise - instead analyze the logs as showed in this [article](https://dev.to/junko911/rails-n-1-queries-and-eager-loading-10eh)
    - **In your PR description include the screenshots of your app's logs before and after the fix**
    - This is the corresponding wireframe view: ![blog all user posts](../images/blog_user_all_posts.png)

#### Integration specs
- Use Capybara to write integration tests for each view in your project.
- Think on the flow of things and group the tests of page in a way that makes sense. For example, one test would check for the things in the page and another test for clicking links on it.

- User index page:
  - I can see the username of all other users.
  - I can see the profile picture for each user.
  - I can see the number of posts each user has written.
  - When I click on a user, I am redirected to that user's show page.

- user show page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see the user's bio.
  - I can see the user's first 3 posts.
  - I can see a button that lets me view all of a user's posts.
  - When I click a user's post, it redirects me to that post's show page.
  - When I click to see all posts, it redirects me to the user's post's index page.

- User post index page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see a post's title.
  - I can see some of the post's body.
  - I can see the first comments on a post.
  - I can see how many comments a post has.
  - I can see how many likes a post has.
  - I can see a section for pagination if there are more posts than fit on the view.
  - When I click on a post, it redirects me to that post's show page.

- Post show page:
  - I can see the post's title.
  - I can see who wrote the post.
  - I can see how many comments it has.
  - I can see how many likes it has.
  - I can see the post body.
  - I can see the username of each commentor.
  - I can see the comment each commentor left.
